### PR TITLE
Don't use Date as a Web IDL type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -60,7 +60,7 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.github.io/ecma262/
     interface DeprecationReportBody : ReportBody {
       [Default] object toJSON();
       readonly attribute DOMString id;
-      readonly attribute Date? anticipatedRemoval;
+      readonly attribute object? anticipatedRemoval;
       readonly attribute DOMString message;
       readonly attribute DOMString? sourceFile;
       readonly attribute unsigned long? lineNumber;


### PR DESCRIPTION
Unfortunately Date is not in https://heycam.github.io/webidl/#idl-types.

Instead, one has to use object in the Web IDL definition. Other examples:
https://html.spec.whatwg.org/multipage/media.html#dom-media-getstartdate
https://html.spec.whatwg.org/multipage/input.html#dom-input-valueasdate